### PR TITLE
All ranks now finish with the same results.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ GTEST_LIB=googletest/build/googlemock/gtest/libgtest.a
 
 .PHONY: all clean
 
-all: $(BIN)/example.exe
+all: $(BIN)/example.exe $(BIN)/example2.exe
 
 $(BIN)/example.exe: $(BIN)/example.o
 	$(CXX) $(CXXFLAGS) -o $(BIN)/example.exe $(BIN)/example.o -L$(GTEST_LIB_DIR) -lgtest
@@ -63,6 +63,14 @@ $(BIN)/example.o: $(SRC)/example.cpp $(INCLUDE)/gtest-mpi-listener.hpp
 	-mkdir $(BIN)
 	$(CXX) $(CXXFLAGS) -c -o $(BIN)/example.o -I$(GTEST_ROOT)/include \
 	-Iinclude $(SRC)/example.cpp
+
+$(BIN)/example2.exe: $(BIN)/example2.o
+	$(CXX) $(CXXFLAGS) -o $(BIN)/example2.exe $(BIN)/example2.o -L$(GTEST_LIB_DIR) -lgtest
+
+$(BIN)/example2.o: $(SRC)/example2.cpp $(INCLUDE)/gtest-mpi-listener.hpp
+	-mkdir $(BIN)
+	$(CXX) $(CXXFLAGS) -c -o $(BIN)/example2.o -I$(GTEST_ROOT)/include \
+	-Iinclude $(SRC)/example2.cpp
 
 
 clean:

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -124,6 +124,7 @@ int main(int argc, char** argv) {
 
   // Adds MPI listener; Google Test owns this pointer
   listeners.Append(new MPIMinimalistPrinter);
+  listeners.Append(new MPISharedTestResults);
 
   // Run tests, then clean up and exit
   RUN_ALL_TESTS();

--- a/src/example2.cpp
+++ b/src/example2.cpp
@@ -119,12 +119,16 @@ int main(int argc, char** argv) {
   ::testing::TestEventListeners& listeners =
       ::testing::UnitTest::GetInstance()->listeners();
 
-  // Remove default listener
-  delete listeners.Release(listeners.default_result_printer());
-
-  // Adds MPI listener; Google Test owns this pointer
-  listeners.Append(new MPIMinimalistPrinter);
-  //listeners.Append(new MPISharedTestResults);
+  //only get json/xml output from rank 0
+  int rank;
+  MPI_Comm_rank(comm, &rank);
+  if(0 != rank){
+	  // Remove default listener
+	  delete listeners.Release(listeners.default_result_printer());
+	  // Remove default file output
+	  delete listeners.Release(listeners.default_xml_generator());
+  }
+  listeners.Append(new MPICollectTestResults);
 
   // Run tests, then clean up and exit
   RUN_ALL_TESTS();


### PR DESCRIPTION
This ensures that --gtest_output will be the same (up to ordering) when
you run as `mpirun -n N test_program --gtest_output=json:filename`

(The previous version would have different outputs for different ranks, which would overwrite each other if using a simple mpirun command. [This could be worked around by using mpiexec and ensuring that each rank got a different --gtest_output file. But that's a pain and not what people expect.] )