### PR TITLE
readme: list BSD-3 license more prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ software
 
 # License
 
-This software is dual-licensed under the MIT and Apache 2.0 licenses,
+This software is triple-licensed under the BSD-3, MIT, and Apache 2.0 licenses,
 and uses some example code from Google Test, which has the following
 license that must be duplicated in its entirety, per its terms:
 


### PR DESCRIPTION
In correspondence with LLNL's IP office, there was some confusion as to whether or not
this code is (or was) BSD-3 licensed, due to the language in the README. This commit
updates that language so that there is no ambiguity as to whether this project is BSD-3
licensed.